### PR TITLE
Removing the part that resets Composer pointer

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2010,7 +2010,6 @@ void cTelnet::atcpComposerCancel()
         return;
     }
     mpComposer->close();
-    mpComposer = nullptr;
     // This will be unaffected by Mud Server encoding:
     std::string output = "*q\nno\n";
     socketOutRaw(output);
@@ -2062,7 +2061,6 @@ void cTelnet::atcpComposerSave(QString txt)
     }
 
     mpComposer->close();
-    mpComposer = nullptr;
 }
 
 // Revamped to take additional [ WARN ], [ ALERT ] and [ INFO ] prefixes and to indent


### PR DESCRIPTION
Removing mpComposer = nullptr; out of here because it will soon be triggered by mpComposer->close()

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
