### PR TITLE
fix for closing Composer window

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2010,7 +2010,6 @@ void cTelnet::atcpComposerCancel()
         return;
     }
     mpComposer->close();
-    mpComposer = nullptr;
     // This will be unaffected by Mud Server encoding:
     std::string output = "*q\nno\n";
     socketOutRaw(output);
@@ -2062,7 +2061,6 @@ void cTelnet::atcpComposerSave(QString txt)
     }
 
     mpComposer->close();
-    mpComposer = nullptr;
 }
 
 // Revamped to take additional [ WARN ], [ ALERT ] and [ INFO ] prefixes and to indent

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -53,3 +53,8 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
     title->setText(newTitle);
     edit->setPlainText(newText);
 }
+
+void dlgComposer::closeEvent(QCloseEvent* event){
+    // Cancel button sends command to exit the in-game editor.  Clicking X just closes the window.
+    mpHost->mTelnet.mpComposer = nullptr;
+}

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -55,6 +55,6 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
 }
 
 void dlgComposer::closeEvent(QCloseEvent* event){
-    // Cancel button sends command to exit the in-game editor.  Clicking X just closes the window.
+    // Cancel button sends command to exit the in-game editor.  Clicking X just closes the composer window.
     mpHost->mTelnet.mpComposer = nullptr;
 }

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -55,6 +55,7 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
 }
 
 void dlgComposer::closeEvent(QCloseEvent* event){
-    // Cancel button sends command to exit the in-game editor.  Clicking X just closes the composer window.
+    // Called when closed via the buttons or the window system
+    // Cancel button sends a command to quit the in-game editor, closing via window system simply closes the composer
     mpHost->mTelnet.mpComposer = nullptr;
 }

--- a/src/dlgComposer.h
+++ b/src/dlgComposer.h
@@ -39,6 +39,7 @@ public:
     dlgComposer(Host*);
 
     void init(const QString &title, const QString &newText);
+    void closeEvent(QCloseEvent* event) override;
 
 public slots:
     void save();


### PR DESCRIPTION
Currently the Save and Cancel buttons call close() on the composer window and then set a pointer to it as null.

If you instead use the window system to close the editor, by clicking X or by right-click and 'close' and so on, it will leave that pointer untouched.  If you try to edit something later, it does not open a composer window because it thinks that there already is one.

With this change, closing the window either way will reset the pointer.

This was the problem causing issue #3300.