### PR TITLE
fix segfault with Composer window

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -220,6 +220,9 @@ cTelnet::~cTelnet()
 #endif
         }
     }
+    if (mpComposer) {
+        mpComposer->close();
+    }
     socket.deleteLater();
 }
 

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -53,3 +53,9 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
     title->setText(newTitle);
     edit->setPlainText(newText);
 }
+
+void dlgComposer::closeEvent(QCloseEvent* event){
+    // Called when closed via the buttons or the window system
+    // Cancel button sends a command to quit the in-game editor, closing via window system simply closes the composer
+    mpHost->mTelnet.mpComposer = nullptr;
+}

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -55,7 +55,7 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
 }
 
 void dlgComposer::closeEvent(QCloseEvent* event){
-    // Called when closed via code in the buttons, cTelnet::~cTelnet(), or the window system
+    // Called when closed via window system or ->close() code (in save/cancel buttons, or cTelnet destructor)
     // Cancel button sends a command to quit the in-game editor, closing via window system simply closes the composer
     mpHost->mTelnet.mpComposer = nullptr;
 }

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -55,7 +55,7 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
 }
 
 void dlgComposer::closeEvent(QCloseEvent* event){
-    // Called when closed via the buttons or the window system
+    // Called when closed via code in the buttons, cTelnet::~cTelnet(), or the window system
     // Cancel button sends a command to quit the in-game editor, closing via window system simply closes the composer
     mpHost->mTelnet.mpComposer = nullptr;
 }

--- a/src/dlgComposer.h
+++ b/src/dlgComposer.h
@@ -39,6 +39,7 @@ public:
     dlgComposer(Host*);
 
     void init(const QString &title, const QString &newText);
+    void closeEvent(QCloseEvent* event) override;
 
 public slots:
     void save();


### PR DESCRIPTION
- Added closeEvent to Composer window which clears pointer to itself in cTelnet when it gets closed
- Added to cTelnet destructor saying to close Composer window