### PR TITLE
Fix: Correct Geyser.UserWindow:new to use a local `me` instead of glo…

### DIFF
--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -82,12 +82,14 @@ Discord::Discord(QObject* parent)
     Discord_Shutdown = reinterpret_cast<Discord_ShutdownPrototype>(mpLibrary->resolve("Discord_Shutdown"));
 
     if (!mpLibrary->isLoaded() || !Discord_Initialize || !Discord_UpdatePresence || !Discord_RunCallbacks || !Discord_Shutdown) {
-        qDebug() << "Could not find Discord library - searched in:";
-        for (auto& libraryPath : qApp->libraryPaths()) {
+        const auto msg = mpLibrary->errorString();
+        auto notFound = msg.contains(QStringLiteral("not found")) || msg.contains(QStringLiteral("No such file or directory"));
+        qDebug().nospace() << "Could not " << (notFound ? "find" : "load") << " Discord library - searched in:";
+        for (const auto& libraryPath : qApp->libraryPaths()) {
             qDebug() << "    " << libraryPath;
         }
-        if (auto msg = mpLibrary->errorString(); !msg.isEmpty()) {
-            qDebug().noquote().nospace() << "  additionally there is an error message: \"" << msg << "\".";
+        if (!msg.isEmpty() && !notFound) {
+            qDebug().noquote().nospace() << "  error: \"" << msg << "\".";
         }
         return;
     }

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -61,7 +61,7 @@ function Geyser.UserWindow:new(cons)
   cons.x = cons.x or 10
   cons.y = cons.y or 140
   --Root Container for UserWindows 
-  me = self.Parent:new(cons)
+  local me = self.Parent:new(cons)
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self


### PR DESCRIPTION
…bal `me`

Per Issue #3513, fixes the incorrect use of global `me` that overwrites user's existing global `me` variable.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
