### PR TITLE
Refactor: make getMudletLuaDefaultPaths() return actual used details …

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -587,6 +587,9 @@ private:
     int mHostID;
     QList<QObject*> objectsToDelete;
     QTimer purgeTimer;
+
+    // Holds the list of places to look for the LuaGlobal.lua file:
+    QStringList mPossiblePaths;
 };
 
 Host& getHostFromLua(lua_State* L);

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -251,11 +251,12 @@ unix:!macx {
 
     LUA_DEFAULT_DIR = $${DATADIR}/lua
 } else:win32 {
-    MINGW_BASE_DIR = $$(MINGW_BASE_DIR)
-    isEmpty(MINGW_BASE_DIR) {
-        MINGW_BASE_DIR = "C:\\Qt\\Tools\\mingw730_32"
+    MINGW_BASE_DIR_TEST = $$(MINGW_BASE_DIR)
+    isEmpty( MINGW_BASE_DIR_TEST ) {
+        MINGW_BASE_DIR_TEST = "C:\\Qt\\Tools\\mingw730_32"
     }
     LIBS +=  \
+        -L"$${MINGW_BASE_DIR_TEST}\\bin" \
         -llua51 \
         -lpcre-1 \
         -llibhunspell-1.6 \
@@ -263,15 +264,13 @@ unix:!macx {
         -lz \                   # for ctelnet.cpp
         -lyajl \
         -lpugixml \
-        -lWs2_32 \
-        -L"$${MINGW_BASE_DIR}\\bin"
+        -lWs2_32
     INCLUDEPATH += \
-                   "C:\\Libraries\\boost_1_71_0" \
-                   "$${MINGW_BASE_DIR}\\include" \
-                   "$${MINGW_BASE_DIR}\\lib\include"
-# Leave this undefined so mudlet::readSettings() preprocessing will fall back to
-# hard-coded executable's /mudlet-lua/lua/ subdirectory
-#    LUA_DEFAULT_DIR = $$clean_path($$system(echo %ProgramFiles%)/lua)
+         "C:\\Libraries\\boost_1_71_0" \
+         "$${MINGW_BASE_DIR_TEST}\\include" \
+         "$${MINGW_BASE_DIR_TEST}\\lib\include"
+    # Leave this unset - we do not need it on Windows:
+    # LUA_DEFAULT_DIR =
 }
 
 unix:!macx {


### PR DESCRIPTION
…(#3497)

The previous code did not link this function to the actual list of paths
used - this makes debugging when things go wrong (or when porting to a new
platform) more difficult than it need be!

It turned out that as well as looping through one list of potential list
of paths to find the `luaGlobal.lua` file from the C++ core that file also
loops through another potential list of paths to find the other files that
should be in the same directory. This is pointless and was misleading as
the latter did not produce anything that the Lua API function
`getMudletLuaDefaultPaths()` would report.

Now the path (but not the file name) that is being tried from the C++ core
is also inserted as a variable `luaGlobalPath` into the Lua interpreter
where it can be used - after converting the directory separator to match
the setting for it within the Lua interpreter - to get the absolute paths
of the other files that `LuaGlobal.lua` loads.

The error reporting has been enhanced to detect more finely a failure to
read the `LuaGlobal.lua` file to say what the problem is.

This is part of my work toward migrating to MSYS2 builds on the Windows
platform.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
