### PR TITLE
Discord button use custom invite URL from game

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2256,6 +2256,7 @@ void Host::processGMCPDiscordInfo(const QJsonObject& discordInfo)
     auto inviteUrl = discordInfo.value(QStringLiteral("inviteurl"));
     // Will be of form: "https://discord.gg/#####"
     if (inviteUrl != QJsonValue::Undefined && !inviteUrl.toString().isEmpty() && inviteUrl.toString() != QStringLiteral("0")) {
+        setDiscordInviteURL(inviteUrl.toString());
         hasInvite = true;
     }
 
@@ -2461,6 +2462,17 @@ void Host::setDiscordApplicationID(const QString& s)
 const QString& Host::getDiscordApplicationID()
 {
     return mDiscordApplicationID;
+}
+
+void Host::setDiscordInviteURL(const QString& s)
+{
+    mDiscordInviteURL = s;
+    writeProfileData(QStringLiteral("discordInviteURL"), s);
+}
+
+const QString& Host::getDiscordInviteURL()
+{
+    return mDiscordInviteURL;
 }
 
 // Compares the current discord username and discriminator against the non-empty

--- a/src/Host.h
+++ b/src/Host.h
@@ -192,6 +192,8 @@ public:
     bool            getMayRedefineColors() { return mServerMayRedefineColors; }
     void            setDiscordApplicationID(const QString& s);
     const QString&  getDiscordApplicationID();
+    void            setDiscordInviteURL(const QString& s);
+    const QString&  getDiscordInviteURL();
     void            setSpellDic(const QString&);
     const QString&  getSpellDic() { return mSpellDic; }
     void            setUserDictionaryOptions(const bool useDictionary, const bool useShared);
@@ -708,6 +710,9 @@ private:
 
     // Will be null/empty if is to use Mudlet's default/own presence
     QString mDiscordApplicationID;
+
+    // Will be null/empty if they have not set their own invite
+    QString mDiscordInviteURL;
 
     // Will be null/empty if we are not concerned to check the use of Discord
     // Rich Presence against the local user currently logged into Discord -

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10018,7 +10018,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
     }
     return warnArgumentValue(L, __func__, QStringLiteral("'%1' can not be converted to the expected numeric Discord application id").arg(inputText));
 }
-/* sketchy part, the Lua*/
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordInviteURL
 int TLuaInterpreter::setDiscordInviteURL(lua_State* L)
 {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10035,11 +10035,12 @@ int TLuaInterpreter::setDiscordInviteURL(lua_State* L)
         // Empty string input - to reset to default the same as the no
         // argument case:
         host.setDiscordInviteURL(QString());
-        // This must always succeed
+        pMudlet->toggleMudletDiscordVisible(false);
         lua_pushboolean(L, true);
         return 1;
     }
     host.setDiscordInviteURL(inputText);
+    pMudlet->toggleMudletDiscordVisible(true);
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10018,6 +10018,31 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
     }
     return warnArgumentValue(L, __func__, QStringLiteral("'%1' can not be converted to the expected numeric Discord application id").arg(inputText));
 }
+/* sketchy part, the Lua*/
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordInviteURL
+int TLuaInterpreter::setDiscordInviteURL(lua_State* L)
+{
+    mudlet* pMudlet = mudlet::self();
+    auto& host = getHostFromLua(L);
+
+    if (!lua_gettop(L)) {
+        host.setDiscordInviteURL(QString());
+        lua_pushboolean(L, true);
+        return 1;
+    }
+    QString inputText = getVerifiedString(L, __func__, 1, "url").trimmed();
+    if (inputText.isEmpty()) {
+        // Empty string input - to reset to default the same as the no
+        // argument case:
+        host.setDiscordInviteURL(QString());
+        // This must always succeed
+        lua_pushboolean(L, true);
+        return 1;
+    }
+    host.setDiscordInviteURL(inputText);
+    lua_pushboolean(L, true);
+    return 1;
+}
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#usingMudletsDiscordID
 int TLuaInterpreter::usingMudletsDiscordID(lua_State* L)
@@ -14024,6 +14049,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getAvailableFonts", TLuaInterpreter::getAvailableFonts);
     lua_register(pGlobalLua, "tempAnsiColorTrigger", TLuaInterpreter::tempAnsiColorTrigger);
     lua_register(pGlobalLua, "setDiscordApplicationID", TLuaInterpreter::setDiscordApplicationID);
+    lua_register(pGlobalLua, "setDiscordInviteURL", TLuaInterpreter::setDiscordInviteURL);
     lua_register(pGlobalLua, "usingMudletsDiscordID", TLuaInterpreter::usingMudletsDiscordID);
     lua_register(pGlobalLua, "setDiscordState", TLuaInterpreter::setDiscordState);
     lua_register(pGlobalLua, "setDiscordGame", TLuaInterpreter::setDiscordGame);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10027,6 +10027,7 @@ int TLuaInterpreter::setDiscordInviteURL(lua_State* L)
 
     if (!lua_gettop(L)) {
         host.setDiscordInviteURL(QString());
+        pMudlet->toggleMudletDiscordVisible(false);
         lua_pushboolean(L, true);
         return 1;
     }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -562,6 +562,7 @@ public:
     static int getAvailableFonts(lua_State* L);
     static int tempAnsiColorTrigger(lua_State*);
     static int setDiscordApplicationID(lua_State* L);
+    static int setDiscordInviteURL(lua_State* L);
     static int usingMudletsDiscordID(lua_State*);
     static int setDiscordState(lua_State*);
     static int setDiscordDetail(lua_State*);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -935,6 +935,7 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
     }
 
     mDiscordApplicationId = readProfileData(profile_name, QStringLiteral("discordApplicationId"));
+    mDiscordInviteURL = readProfileData(profile_name, QStringLiteral("discordInviteURL"));
 
     // val will be null if this is the first time the profile has been read
     // since an update to a Mudlet version supporting Discord - so a toint()

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -139,6 +139,7 @@ private:
     QLineEdit* delete_profile_lineedit;
     QPushButton* delete_button;
     QString mDiscordApplicationId;
+    QString mDiscordInviteURL;
     QAction* mpAction_revealPassword;
     // true for the duration of the 'Copy profile' action
     bool mCopyingProfile{};

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -377,6 +377,7 @@
     "setDiscordDetail": "setDiscordDetail(text)",
     "setDiscordElapsedStartTime": "setDiscordElapsedStartTime(time)",
     "setDiscordGame": "setDiscordGame(text)",
+    "setDiscordInviteURL": "setDiscordInviteURL(url)",
     "setDiscordLargeIcon": "setDiscordLargeIcon(iconName)",
     "setDiscordLargeIconText": "setDiscordLargeIconText(text)",
     "setDiscordParty": "setDiscordParty(current, max)",

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2379,6 +2379,11 @@ void mudlet::slot_discord()
     openWebPage(invite.isEmpty() ? mMudletDiscordInvite : invite);
 }
 
+void mudlet::slot_mudlet_discord()
+{
+    openWebPage(mMudletDiscordInvite);
+}
+
 void mudlet::slot_reconnect()
 {
     Host* pHost = getActiveHost();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2385,7 +2385,9 @@ void mudlet::slot_mudlet_discord()
 }
 
 void mudlet::toggleMudletDiscordVisible(bool vis){
-    mpActionMudletDiscord->setVisible(vis);
+    if ( mpActionMudletDiscord->isVisible() != vis ) {
+        mpActionMudletDiscord->setVisible(vis);
+    }
 }
 
 void mudlet::slot_reconnect()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1424,7 +1424,7 @@ void mudlet::slot_tab_changed(int tabID)
 
     // If game has custom invite then make secondary Discord option visible.
     bool isVis = mpActionMudletDiscord->isVisible();
-    if ( mpCurrentActiveHost->getDiscordInviteURL().isEmpty && isVis ) {
+    if ( mpCurrentActiveHost->getDiscordInviteURL().isEmpty() && isVis ) {
         mpActionMudletDiscord->setVisible(false);
     } else if ( !isVis ) {
         mpActionMudletDiscord->setVisible(true);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -218,6 +218,7 @@ mudlet::mudlet()
 , mpActionFullScreenView(nullptr)
 , mpActionHelp(nullptr)
 , mpActionDiscord(nullptr)
+, mpActionMudletDiscord(nullptr)
 , mpActionIRC(nullptr)
 , mpButtonDiscord(nullptr)
 , mpActionKeys(nullptr)
@@ -407,11 +408,18 @@ mudlet::mudlet()
     mpActionDiscord->setIconText(QStringLiteral("Discord"));
     mpActionDiscord->setObjectName(QStringLiteral("openDiscord"));
 
+    mpActionMudletDiscord = new QAction(tr("Mudlet Discord"), this);
+    mpActionMudletDiscord->setIcon(QIcon(QStringLiteral(":/icons/Discord-Logo-Color.png")));
+    mpActionMudletDiscord->setIconText(QStringLiteral("Mudlet Discord"));
+    mpActionMudletDiscord->setObjectName(QStringLiteral("openMudletDiscord"));
+    mpActionMudletDiscord->setVisible(false); // Mudlet Discord becomes visible if game has custom invite
+
     mpActionIRC = new QAction(tr("Open IRC"), this);
     mpActionIRC->setIcon(QIcon(QStringLiteral(":/icons/internet-telephony.png")));
     mpActionIRC->setObjectName(QStringLiteral("openIRC"));
 
     mpButtonDiscord->addAction(mpActionDiscord);
+    mpButtonDiscord->addAction(mpActionMudletDiscord);
     mpButtonDiscord->addAction(mpActionIRC);
     mpButtonDiscord->setDefaultAction(mpActionDiscord);
 
@@ -546,6 +554,7 @@ mudlet::mudlet()
     connect(mpActionMapper.data(), &QAction::triggered, this, &mudlet::slot_mapper);
     connect(mpActionIRC.data(), &QAction::triggered, this, &mudlet::slot_irc);
     connect(mpActionDiscord.data(), &QAction::triggered, this, &mudlet::slot_discord);
+    connect(mpActionMudletDiscord.data(), &QAction::triggered, this, &mudlet::slot_mudlet_discord);
     connect(mpActionPackageManager.data(), &QAction::triggered, this, &mudlet::slot_package_manager);
     connect(mpActionModuleManager.data(), &QAction::triggered, this, &mudlet::slot_module_manager);
     connect(mpActionPackageExporter.data(), &QAction::triggered, this, &mudlet::slot_package_exporter);
@@ -563,7 +572,7 @@ mudlet::mudlet()
     connect(dactionVideo, &QAction::triggered, this, &mudlet::slot_show_help_dialog_video);
     connect(dactionForum, &QAction::triggered, this, &mudlet::slot_show_help_dialog_forum);
     connect(dactionIRC, &QAction::triggered, this, &mudlet::slot_irc);
-    connect(dactionDiscord, &QAction::triggered, this, &mudlet::slot_discord);
+    connect(dactionDiscord, &QAction::triggered, this, &mudlet::slot_mudlet_discord);
     connect(dactionLiveHelpChat, &QAction::triggered, this, &mudlet::slot_irc);
 #if defined(INCLUDE_UPDATER)
     // Show the update option if the code is present AND if this is a
@@ -1412,6 +1421,14 @@ void mudlet::slot_tab_changed(int tabID)
     setWindowTitle(mpCurrentActiveHost->getName() + " - " + version);
 
     dactionInputLine->setChecked(mpCurrentActiveHost->getCompactInputLine());
+
+    // If game has custom invite then make secondary Discord option visible.
+    bool isVis = mpActionMudletDiscord->isVisible();
+    if ( mpCurrentActiveHost->getDiscordInviteURL().isEmpty && isVis ) {
+        mpActionMudletDiscord->setVisible(false);
+    } else if ( !isVis ) {
+        mpActionMudletDiscord->setVisible(true);
+    }
 
     // Restore the multi-view mode if it was enabled:
     if (mpTabBar->count() > 1) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2354,7 +2354,12 @@ void mudlet::slot_irc()
 
 void mudlet::slot_discord()
 {
-    openWebPage(mMudletDiscordInvite);
+    Host* pHost = getActiveHost();
+    QString invite;
+    if (pHost) {
+        invite = pHost->getDiscordInviteURL();
+    }
+    openWebPage(invite.isEmpty() ? mMudletDiscordInvite : invite);
 }
 
 void mudlet::slot_reconnect()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2384,6 +2384,10 @@ void mudlet::slot_mudlet_discord()
     openWebPage(mMudletDiscordInvite);
 }
 
+void mudlet::toggleMudletDiscordVisible(bool vis){
+    mpActionMudletDiscord->setVisible(vis);
+}
+
 void mudlet::slot_reconnect()
 {
     Host* pHost = getActiveHost();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -519,6 +519,7 @@ public slots:
     void slot_irc();
     void slot_discord();
     void slot_mudlet_discord();
+    void toggleMudletDiscordVisible(bool vis);
     void slot_package_manager();
     void slot_package_exporter();
     void slot_module_manager();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -518,6 +518,7 @@ public slots:
     void slot_close_profile_requested(int);
     void slot_irc();
     void slot_discord();
+    void slot_mudlet_discord();
     void slot_package_manager();
     void slot_package_exporter();
     void slot_module_manager();
@@ -657,6 +658,7 @@ private:
     QPointer<QAction> mpActionFullScreenView;
     QPointer<QAction> mpActionHelp;
     QPointer<QAction> mpActionDiscord;
+    QPointer<QAction> mpActionMudletDiscord;
     QPointer<QAction> mpActionIRC;
     QPointer<QToolButton> mpButtonDiscord;
     QPointer<QAction> mpActionKeys;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Changed the Discord button to use custom invite URL from game.  Added secondary drop-down item that goes to Mudlet Discord, have it be hidden if no custom invite.  Made GMCP handler save the URL.  Made Lua function for scripters to set the URL.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
