### PR TITLE
Tim profiles

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,12 +218,15 @@ int main(int argc, char* argv[])
     QCommandLineOption mirrorToStdout(QStringList() << "m" << "mirror", QCoreApplication::translate("main", "Mirror output of all consoles to STDOUT"));
     parser.addOption(mirrorToStdout);
 
-    parser.parse(app->arguments());
+    bool parsedCommandLineOk = parser.parse(app->arguments());
 
     // Non-GUI actions --help and --version as suggested by GNU coding standards,
     // section 4.7: http://www.gnu.org/prep/standards/standards.html#Command_002dLine-Interfaces
     QStringList texts;
-    if (parser.isSet(showHelp)) {
+    if (!parsedCommandLineOk || parser.isSet(showHelp)) {
+        if (!parsedCommandLineOk) {
+            texts << qsl("%1\n\n").arg(QCoreApplication::translate("main", "Error: %1").arg(parser.errorText()));
+        }
         // Do "help" action
         texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Usage: %1 [OPTION...]\n"
                                "       -h, --help           displays this message.\n"
@@ -276,7 +279,7 @@ int main(int argc, char* argv[])
         texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Report bugs to: https://github.com/Mudlet/Mudlet/issues"));
         texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Project home page: http://www.mudlet.org/"));
         std::cout << texts.join(QString()).toStdString();
-        return 0;
+        return parsedCommandLineOk ? 0 :-1;
     }
 
     if (parser.isSet(showVersion)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char* argv[])
     }
 
     QCommandLineParser parser;
-    QCommandLineOption profileToOpen(qsl("profile"), QCoreApplication::translate("main", "Profile to open automatically"), QCoreApplication::translate("main", "profile"));
+    QCommandLineOption profileToOpen(QStringList() << qsl("p") << qsl("profile"), QCoreApplication::translate("main", "Profile to open automatically"), QCoreApplication::translate("main", "profile"));
     parser.addOption(profileToOpen);
 
     QCommandLineOption showHelp(QStringList() << "h" <<"help", QCoreApplication::translate("main", "Display help and exit"));
@@ -229,7 +229,7 @@ int main(int argc, char* argv[])
                                "       -h, --help           displays this message.\n"
                                "       -v, --version        displays version information.\n"
                                "       -q, --quiet          no splash screen on startup.\n"
-                               "       --profile=<profile>  additional profile to open\n\n"
+                               "       -p, --profile=<profile>  additional profile to open, may be repeated\n\n"
                                "There are other inherited options that arise from the Qt Libraries which are\n"
                                "less likely to be useful for normal use of this application:")
                  .arg(QLatin1String(APP_TARGET)));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2507,18 +2507,18 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     hostList.removeDuplicates();
     bool openedProfile = false;
 
-    for (auto& pHost : cliProfiles){
-        if (hostList.contains(pHost)) {
-            doAutoLogin(pHost);
+    for (auto& hostName : cliProfiles){
+        if (hostList.contains(hostName)) {
+            doAutoLogin(hostName);
             openedProfile = true;
-            hostList.removeOne(pHost);
+            hostList.removeOne(hostName);
         }
     }
 
-    for (auto& pHost : hostList) {
-        QString val = readProfileData(pHost, qsl("autologin"));
+    for (auto& hostName : hostList) {
+        QString val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
-            doAutoLogin(pHost);
+            doAutoLogin(hostName);
             openedProfile = true;
         }
     }


### PR DESCRIPTION
Some improvements to @atari2600tim 's PR:

* Support -p as well as --profile command line option.
* Exit (with -1) return value on command line parsing errors, also show the help dialogue.
* Rename a poorly & confusingly named variable.

Signed-off by: Stephen Lyons <slysven@virginmedia.com>